### PR TITLE
34 Add `.env.example` files

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,19 @@
+// Example `.env` file. Create your own personal `.env` file based on this.
+// Interpret any <BRACKETS> as a value you must replace.
+//
+// If a commit requires new environment variables be set, please add them to
+// this `.env.example` file for all other developers to see and compare their
+// own `.env` files and ensure all have the required environment variables set.
+//
+// Also include a brief explanation of what the environment variable does
+// above its declaration.
+
+// The mongo URI to access the database.
+MONGO_URI=mongodb://localhost:<MONGO_PORT>/<DATABASE_NAME>
+// Port on which the backend server will run.
+PORT=<PORT>
+// JavaScript Web Token Secret. Value expected to be received by the backend
+// server.
+JWT_SECRET=<A_STRING>
+// JavaScript Web Token Expiration Time.
+JWT_EXPIRATION_TIME=<A_NUMBER>

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,16 @@
+// Example `.env` file. Create your own personal `.env` file based on this.
+// Interpret any <BRACKETS> as a value you must replace.
+//
+// If a commit requires new environment variables be set, please add them to
+// this `.env.example` file for all other developers to see and compare their
+// own `.env` files and ensure all have the required environment variables set.
+//
+// Also include a brief explanation of what the environment variable does
+// above its declaration.
+//
+// When using `vite`, all environment variables that are to be accessed by the
+// code must be prefixed with "VITE_", and can be imported into the code by
+// using `import.meta.env.VITE_<YOUR_VARIABLE>`.
+
+// API URL to access the backend server.
+VITE_API_URL=https://localhost:<BACKEND_PORT>/<API_END_POINT_URI>


### PR DESCRIPTION
Include files `/frontend/.env.example` and `/backend/.env.example` to keep
track of the various environment variables that need to be set in order for
the project to run. **Do not use these to put the actual values of the
environment variables**. Instead, provide an abstract, but clear template of
how each variable should be set using `<BRACKETS>` to specify where the
specific values should be provided.
